### PR TITLE
Fixes to some problems I encountered

### DIFF
--- a/src/Dormilich/WebService/RIPE/Object.php
+++ b/src/Dormilich/WebService/RIPE/Object.php
@@ -236,11 +236,19 @@ abstract class Object implements ObjectInterface, \ArrayAccess, \IteratorAggrega
                 throw new IncompleteRPSLObjectException('Required attribute ' . $attr->getName() . ' is not set.');
             }
             if ($attr->isDefined()) {
-                foreach ((array) $attr->getValue() as $value) {
+                if($attr->getValue() instanceof AttributeValue) {
                     $attributes[] = [
-                        "name"  => $attr->getName(), 
-                        "value" => (string) $value, 
+                        "name"  => $attr->getName(),
+                        "value" => (string) $attr->getValue(),
                     ];
+                }
+                else {
+                    foreach ((array) $attr->getValue() as $value) {
+                        $attributes[] = [
+                            "name"  => $attr->getName(),
+                            "value" => (string) $value,
+                        ];
+                    }
                 }
             }
         }

--- a/src/Dormilich/WebService/RIPE/WebService.php
+++ b/src/Dormilich/WebService/RIPE/WebService.php
@@ -305,6 +305,13 @@ class WebService
                 continue;
             }
             $args   = array_filter($error['args'], $filter);
+
+            // ripe may return not enough args (eg empty netname)
+            if(substr_count($text, '%') > count($args)) {
+                $list[] = $text;
+                continue;
+            }
+
             $list[] = vsprintf($text, array_map($map, $args));
         }
 

--- a/tests/attribute/AttributeValueTest.php
+++ b/tests/attribute/AttributeValueTest.php
@@ -97,4 +97,18 @@ class AttributeValueTest extends PHPUnit_Framework_TestCase
 		$attr->setValue($value);
 		$this->assertSame('xyz', $attr->getValue());
 	}
+
+	public function testAttributeValueToArray() {
+		$reg   = new RegObject;
+		$value = new AttributeValue('something');
+		$value->setLink('http://www.example.com/something');
+
+		$reg['source'] = 'TEST';
+		$reg['register'] = $value;
+
+		$this->assertEquals($reg->toArray()['objects']['object'][0]['attributes']['attribute'], [
+				['name' => 'register', 'value' => 'something'],
+				['name' => 'source', 'value' => 'TEST']
+			]);
+	}
 }


### PR DESCRIPTION
Casting an AttributeValue to array results in members link, comment, ... being returned as values when calling toArray() on the object.

Also sometimes ripe doesn't provide enough args to their error messages (example is empty netname). This results in vsprintf complaining about not enough params.
