### PR TITLE
descr attribute no longer required on some objects

### DIFF
--- a/src/Dormilich/WebService/RIPE/RPSL/AutNum.php
+++ b/src/Dormilich/WebService/RIPE/RPSL/AutNum.php
@@ -40,7 +40,7 @@ class AutNum extends Object
     {
         $this->create('aut-num',    Attr::REQUIRED, Attr::SINGLE);
         $this->create('as-name',    Attr::REQUIRED, Attr::SINGLE);
-        $this->create('descr',      Attr::REQUIRED, Attr::MULTIPLE);
+        $this->create('descr',      Attr::OPTIONAL, Attr::MULTIPLE);
         $this->create('member-of',  Attr::OPTIONAL, Attr::MULTIPLE);
         $this->create('import-via', Attr::OPTIONAL, Attr::MULTIPLE);
         $this->create('import',     Attr::OPTIONAL, Attr::MULTIPLE);

--- a/src/Dormilich/WebService/RIPE/RPSL/Inet6num.php
+++ b/src/Dormilich/WebService/RIPE/RPSL/Inet6num.php
@@ -36,7 +36,7 @@ class Inet6num extends Object
     {
         $this->create('inet6num',    Attr::REQUIRED, Attr::SINGLE);
         $this->create('netname',     Attr::REQUIRED, Attr::SINGLE);
-        $this->create('descr',       Attr::REQUIRED, Attr::MULTIPLE);
+        $this->create('descr',       Attr::OPTIONAL, Attr::MULTIPLE);
         $this->create('country',     Attr::REQUIRED, Attr::MULTIPLE);
         $this->create('geoloc',      Attr::OPTIONAL, Attr::SINGLE);
         $this->create('language',    Attr::OPTIONAL, Attr::MULTIPLE);

--- a/src/Dormilich/WebService/RIPE/RPSL/Inetnum.php
+++ b/src/Dormilich/WebService/RIPE/RPSL/Inetnum.php
@@ -126,7 +126,7 @@ class Inetnum extends Object
     {
         $this->create('inetnum',     Attr::REQUIRED, Attr::SINGLE);
         $this->create('netname',     Attr::REQUIRED, Attr::SINGLE);
-        $this->create('descr',       Attr::REQUIRED, Attr::MULTIPLE);
+        $this->create('descr',       Attr::OPTIONAL, Attr::MULTIPLE);
         $this->create('country',     Attr::REQUIRED, Attr::MULTIPLE);
         $this->create('geoloc',      Attr::OPTIONAL, Attr::SINGLE);
         $this->create('language',    Attr::OPTIONAL, Attr::MULTIPLE);


### PR DESCRIPTION
'descr' attribute is no longer required on inetnum, inet6num and aut-num  …

see:
https://www.ripe.net/ripe/mail/archives/ncc-announce/2016-June/001051.html
https://www.ripe.net/ripe/mail/archives/ncc-announce/2016-April/001033.html
