### PR TITLE
Inetnum::convertCIDR() fix for 64 bit systems.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.7 - 2019-01-24
+
+- Fixed:  Test for the end of IPv4 address space in Inetnum::convertCIDR() now works properly on 64 bit systems.
+
+## 1.0.6 - 2018-11-26
+
+- Updated RPSL definitions to RIPE DB version 1.92
+
 ## 1.0.5 - 2017-10-17
 
 - Updated RPSL definitions to RIPE DB version 1.90

--- a/src/Dormilich/WebService/RIPE/RPSL/Inetnum.php
+++ b/src/Dormilich/WebService/RIPE/RPSL/Inetnum.php
@@ -110,7 +110,9 @@ class Inetnum extends Object
         $netsize = 1 << (32 - $prefix);
         $end_num = $ipnum + $netsize - 1;
 
-        if ($end_num >= (1 << 32)) {
+        // adjusted so that this works on 32 and 64 bit systems
+				$unsignedEndNum = sprintf("%u", $ipnum) + $netsize - 1;
+				if ($unsignedEndNum > 4294967295) {
             return false;
         }
 

--- a/tests/object/InetnumInputTest.php
+++ b/tests/object/InetnumInputTest.php
@@ -99,5 +99,14 @@ class InetnumInputTest extends TestCase
         $this->assertSame($bogus, $net2->getPrimaryKey());
         $this->assertSame($bogus, $net3->getPrimaryKey());
         $this->assertSame('255.255.255.254/30', $net4->getPrimaryKey());
+		}
+
+    public function testHighRangeWithCidr()
+		{
+        // ensure no issues with high ranges on 64 bit systems
+        $range = '255.255.255.240 - 255.255.255.255';
+        $net = new Inetnum('255.255.255.240/28');
+
+        $this->assertSame($range, $net->getPrimaryKey());
     }
 }


### PR DESCRIPTION
Test for the end of IPv4 address space in Inetnum::convertCIDR() now works properly on 64 bit systems. Unit test added to cover edge case for this area.